### PR TITLE
Update tox test matrix to include Wagtail 5.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+* Update for Wagtail 5.1
+
 1.0.0 - 27th July 2023
 ----------------------
 * Support Wagtail 4.2 (@katdom13)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,7 @@
 Unreleased
 ----------
+* Drop support for Wagtail versions 4.2 and 5.0 (@katdom13)
+* Support for Wagtail 5.2 (@katdom13)
 
 * Update for Wagtail 5.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{38,39,310}-dj{32,41}-wagtail{41,42,50,51}
-    py311-dj41-wagtail{41,42,50,51}
-    py311-dj42-wagtail{50,51}
+    py{38,39,310}-dj{32,41}-wt{41,51,52}
+    py311-dj41-wt{41,51,52}
+    py311-dj42-wt{51,52,main}
     flake8
     isort
     black
@@ -23,9 +23,8 @@ deps =
     dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<4.3
     wagtail41: wagtail>=4.1,<4.2
-    wagtail42: wagtail>=4.2,<5.0
-    wagtail50: wagtail>=5.0,<5.1
     wagtail51: wagtail>=5.1,<5.2
+    wagtail52: wagtail>=5.2,<5.3
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
 install_command = pip install -U {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{38,39,310}-dj{32}-wagtail{41,42,50,51}
-    py{38,39,310,311}-dj{41}-wagtail{41,42}
-    py{310,311}-dj{42}-wagtail{50,51,main}
+    py{38,39,310}-dj{32,41}-wagtail{41,42,50,51}
+    py311-dj41-wagtail{41,42,50,51}
+    py311-dj42-wagtail{50,51}
     flake8
     isort
     black

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{38,39,310}-dj{32,41}-wagtail{41,42}
-    py{310,311}-dj{41}-wagtail{41}
-    py{310,311}-dj{42}-wagtail{50,main}
+    py{38,39,310}-dj{32}-wagtail{41,42,50,51}
+    py{38,39,310,311}-dj{41}-wagtail{41,42}
+    py{310,311}-dj{42}-wagtail{50,51,main}
     flake8
     isort
     black
@@ -24,7 +24,8 @@ deps =
     dj42: Django>=4.2,<4.3
     wagtail41: wagtail>=4.1,<4.2
     wagtail42: wagtail>=4.2,<5.0
-    wagtail50: wagtail>=5.0,<6.0
+    wagtail50: wagtail>=5.0,<5.1
+    wagtail51: wagtail>=5.1,<5.2
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
 install_command = pip install -U {opts} {packages}

--- a/wagtail_storages/tests/settings.py
+++ b/wagtail_storages/tests/settings.py
@@ -2,6 +2,8 @@ import os
 
 import django.utils.crypto
 
+from wagtail import VERSION as WAGTAIL_VERSION
+
 TESTS_PATH = os.path.dirname(os.path.abspath(__file__))
 
 SECRET_KEY = django.utils.crypto.get_random_string(50)
@@ -43,6 +45,13 @@ DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "db.sql
 MEDIA_ROOT = os.path.join(TESTS_PATH, "media")
 
 STATIC_ROOT = os.path.join(TESTS_PATH, "static")
+
+if WAGTAIL_VERSION >= (5, 2):
+    # when running tests with Wagtail 5.2+, we need to set the STATIC_URL explicitly,
+    # otherwise the test server will not start.
+    # This happens when running tests against the main branch of Wagtail
+    # so I am assuming that an upcoming release will require this.
+    STATIC_URL = "/static/"
 
 ROOT_URLCONF = "wagtail_storages.tests.urls"
 


### PR DESCRIPTION
## [Wagtail 5.2 release notes](https://docs.wagtail.org/en/stable/releases/5.2.html)

## Include PR for Wagtail 5.1: https://github.com/torchbox-forks/wagtail-storages/pull/1

## Upstream PR: https://github.com/torchbox/wagtail-storages/pull/41

Changes:
- Update test matrix to include Wagtail 5.2
- Drop Wagtail 4.2 and 5.0 from the test matrix due to them reaching EOL (https://endoflife.date/wagtail)