### PR TITLE
Update tox testing to reflect Wagtail 6.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+unreleased
+----------
+
+- Wagtail 6.3 support/testing
+
+
 2.0 - 18th September 2024
 -------------------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{310,311}-dj42-wagtail{52,61,62}
-    py{311,312}-dj{50}-wagtail{52,61,62}
-    py{311,312}-dj{51}-wagtail{61,62}
+    py{310,311}-dj42-wagtail{52,62,63}
+    py{311,312}-dj{50}-wagtail{52,62,63}
+    py{311,312}-dj{51}-wagtail{63}
     flake8
     isort
     black
@@ -25,9 +25,8 @@ deps =
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
     wagtail52: wagtail>=5.2,<5.3
-    wagtail60: wagtail>=6.0,<6.1
-    wagtail61: wagtail>=6.1,<6.2
     wagtail62: wagtail>=6.2,<6.3
+    wagtail63: wagtail>=6.3,<6.4
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
 commands =


### PR DESCRIPTION
But also remove the wagtail60 and wagtail61 testing as they are not LTS versions or the latest version.