### PR TITLE
Check support for wagtail 6.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,9 @@
-unreleased
+Unreleased
 ----------
 
-- Wagtail 6.3 support/testing
-
+* Add tests for Wagtail 6.3, 6.4 and Python 3.13 (@ianmeigh)
+* Update tests to consider tasks managed by django-tasks are now deferred until
+  the current transaction is committed (@ianmeigh)
 
 2.0 - 18th September 2024
 -------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Internet :: WWW/HTTP
     Framework :: Django
     Framework :: Django :: 4.2

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
 commands =
-    coverage run --source="{toxinidir}/wagtail_storages" -m django test wagtail_storages
+    coverage run --source="{toxinidir}/wagtail_storages" -m django test {posargs:wagtail_storages}
     django-admin check
     django-admin makemigrations --check --noinput
     coverage report -m --omit="{toxinidir}/wagtail_storages/tests/*" --fail-under=80

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{310,311}-dj42-wagtail{52,62,63}
-    py{311,312}-dj{50}-wagtail{52,62,63}
-    py{311,312}-dj{51}-wagtail{63}
+    py{310,311}-dj42-wagtail{52,63,64}
+    py{311,312}-dj{50}-wagtail{52,63,64}
+    py{311,312,313}-dj{51}-wagtail{63,64}
     flake8
     isort
     black
@@ -12,6 +12,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 use_frozen_constraints = true
@@ -27,6 +28,7 @@ deps =
     wagtail52: wagtail>=5.2,<5.3
     wagtail62: wagtail>=6.2,<6.3
     wagtail63: wagtail>=6.3,<6.4
+    wagtail64: wagtail>=6.4,<6.5
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ deps =
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
     wagtail52: wagtail>=5.2,<5.3
-    wagtail62: wagtail>=6.2,<6.3
     wagtail63: wagtail>=6.3,<6.4
     wagtail64: wagtail>=6.4,<6.5
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail

--- a/wagtail_storages/tests/test_signal_handlers.py
+++ b/wagtail_storages/tests/test_signal_handlers.py
@@ -108,9 +108,10 @@ class TestPurgeDocumentsWhenCollectionSavedWithRestrictions(CreateBucket, TestCa
         private_collection = CollectionViewRestrictionFactory().collection
         DocumentFactory(collection=private_collection)
         with mock.patch(URLOPEN_PATH) as urlopen_mock:
-            purge_documents_when_collection_saved_with_restrictions(
-                sender=private_collection._meta.model, instance=private_collection
-            )
+            with self.captureOnCommitCallbacks(execute=True):
+                purge_documents_when_collection_saved_with_restrictions(
+                    sender=private_collection._meta.model, instance=private_collection
+                )
         urlopen_mock.assert_called()
 
     @override_settings(
@@ -132,9 +133,10 @@ class TestPurgeDocumentsWhenCollectionSavedWithRestrictions(CreateBucket, TestCa
         collection = CollectionFactory()
         DocumentFactory.create_batch(10, collection=collection)
         with mock.patch(URLOPEN_PATH) as urlopen_mock:
-            purge_documents_when_collection_saved_with_restrictions(
-                sender=collection._meta.model, instance=collection
-            )
+            with self.captureOnCommitCallbacks(execute=True):
+                purge_documents_when_collection_saved_with_restrictions(
+                    sender=collection._meta.model, instance=collection
+                )
         urlopen_mock.assert_not_called()
 
 
@@ -158,9 +160,10 @@ class TestPurgeDocumentFromCacheWhenSaved(CreateBucket, TestCase):
     def test_create_new_document_purges_cache_for_that_url(self):
         document = DocumentFactory()
         with mock.patch(URLOPEN_PATH) as urlopen_mock:
-            purge_document_from_cache_when_saved(
-                sender=document._meta.model, instance=document
-            )
+            with self.captureOnCommitCallbacks(execute=True):
+                purge_document_from_cache_when_saved(
+                    sender=document._meta.model, instance=document
+                )
         urlopen_mock.assert_called()
 
     @override_settings(
@@ -181,7 +184,8 @@ class TestPurgeDocumentFromCacheWhenSaved(CreateBucket, TestCase):
     def test_delete_document_purges_cache_for_that_url(self):
         document = DocumentFactory()
         with mock.patch(URLOPEN_PATH) as urlopen_mock:
-            purge_document_from_cache_when_deleted(
-                sender=document._meta.model, instance=document
-            )
+            with self.captureOnCommitCallbacks(execute=True):
+                purge_document_from_cache_when_deleted(
+                    sender=document._meta.model, instance=document
+                )
         urlopen_mock.assert_called()


### PR DESCRIPTION
Includes changes from https://github.com/torchbox/wagtail-storages/pull/57 (Update tox testing to reflect Wagtail 6.3)